### PR TITLE
Add last logout bank value comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ the change in price your items have experienced. The plugin will show the differ
 prices to the oldest datapoint within your selected time frame. The percentage value shown is a difference
 in UNIT price of the item, not the evolution of how the entire stack's price has changed.
 
+You can also choose `LAST_LOGOUT` to compare your current bank prices with the most recent saved
+bank snapshot from the previous RuneLite session.
+
 The plugin works by creating a timestamp of your bank every time you open up the main tab, up to a maximum
 of once per hour. This data is saved in .runelite\bank-value-changes\priceHistoryData.json
 

--- a/src/main/java/com/bankvaluechanges/BankValueChangesConfig.java
+++ b/src/main/java/com/bankvaluechanges/BankValueChangesConfig.java
@@ -8,6 +8,7 @@ import net.runelite.client.config.ConfigItem;
 public interface BankValueChangesConfig extends Config
 {
 	enum TimeScale {
+		LAST_LOGOUT,
 		HALF_DAY,
 		DAY,
 		WEEK,

--- a/src/main/java/com/bankvaluechanges/BankValueChangesPlugin.java
+++ b/src/main/java/com/bankvaluechanges/BankValueChangesPlugin.java
@@ -56,6 +56,7 @@ public class BankValueChangesPlugin extends Plugin {
     public static Gson GSON;
     private static Long timeBand;
     private final ArrayList<PriceSnapshot> priceSnapshots = new ArrayList<>();
+    private long currentSessionStartedAt;
     public Map<Integer, Double> valueChanges = new HashMap<>();
 
     static
@@ -87,6 +88,7 @@ public class BankValueChangesPlugin extends Plugin {
 
     @Override
     protected void startUp() throws Exception {
+        currentSessionStartedAt = System.currentTimeMillis();
         GSON = gson.newBuilder().create();
         overlayManager.add(overlay);
         loadPriceData();
@@ -115,7 +117,8 @@ public class BankValueChangesPlugin extends Plugin {
         if (!priceSnapshots.isEmpty()) {
             // Compare time with latest entry, if within half an hour of latest entry, don't update
             PriceSnapshot latest = priceSnapshots.get(priceSnapshots.size() - 1);
-            if (System.currentTimeMillis() <= latest.getTimestamp() + HALF_HOUR_IN_MILLIS) {
+            if (latest.getTimestamp() >= currentSessionStartedAt
+                && System.currentTimeMillis() <= latest.getTimestamp() + HALF_HOUR_IN_MILLIS) {
                 return;
             }
         }
@@ -169,6 +172,9 @@ public class BankValueChangesPlugin extends Plugin {
 
     private void setTimeBand(BankValueChangesConfig.TimeScale scale) {
         switch(scale) {
+            case LAST_LOGOUT:
+                timeBand = null;
+                break;
             case HALF_DAY:
                 timeBand = HALF_DAY_IN_MILLIS;
                 break;
@@ -228,7 +234,18 @@ public class BankValueChangesPlugin extends Plugin {
     }
 
     private void populateDifferenceMap() {
+        valueChanges.clear();
+
         if (priceSnapshots.isEmpty()) {
+            return;
+        }
+
+        if (config.chooseTimeScale() == BankValueChangesConfig.TimeScale.LAST_LOGOUT) {
+            PriceSnapshot lastLogoutSnapshot = getLastLogoutSnapshot();
+            PriceSnapshot latest = priceSnapshots.get(priceSnapshots.size() - 1);
+            if (lastLogoutSnapshot != null && latest.getTimestamp() >= currentSessionStartedAt) {
+                calculatePriceDiffPercentage(lastLogoutSnapshot);
+            }
             return;
         }
 
@@ -248,6 +265,16 @@ public class BankValueChangesPlugin extends Plugin {
         // Didn't find any snapshots outside the given time band
         // so just give the oldest one within it
         calculatePriceDiffPercentage(priceSnapshots.get(0));
+    }
+
+    private PriceSnapshot getLastLogoutSnapshot() {
+        for (int i = priceSnapshots.size() - 1; i >= 0; i--) {
+            PriceSnapshot snapshot = priceSnapshots.get(i);
+            if (snapshot.getTimestamp() < currentSessionStartedAt) {
+                return snapshot;
+            }
+        }
+        return null;
     }
 
     private void calculatePriceDiffPercentage(PriceSnapshot oldest) {


### PR DESCRIPTION
## Summary
- add a `LAST_LOGOUT` time scale option for comparing current bank prices against the newest saved snapshot from the previous RuneLite session
- take a fresh snapshot on the first bank open of a new session even if the previous snapshot is less than 30 minutes old
- clear stale overlay deltas before recalculating and document the new mode in the README

## Verification
- `git diff --check`
- `JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStoreType=Windows-ROOT" ./gradlew.bat test`

This is an AI-assisted contribution prepared with Codex for Chris / nexiumbiz-debug.

Fixes #3
